### PR TITLE
Generic deployment reconciler

### DIFF
--- a/pkg/common/kubernetes_types.go
+++ b/pkg/common/kubernetes_types.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type KubernetesObject interface {
+	metav1.Object
+	runtime.Object
+}
+
+func ObjectInfo(obj KubernetesObject) string {
+	return fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+}
+
+func ObjectKey(obj KubernetesObject) types.NamespacedName {
+	return types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+}

--- a/pkg/controller/discoveryservice/ca_certificate.go
+++ b/pkg/controller/discoveryservice/ca_certificate.go
@@ -19,7 +19,7 @@ func (r *ReconcileDiscoveryService) reconcileCA(ctx context.Context) (reconcile.
 
 	r.logger.V(1).Info("Reconciling CA certificate")
 	ca := &operatorv1alpha1.DiscoveryServiceCertificate{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getCACertName(), Namespace: r.getNamespace()}, ca)
+	err := r.client.Get(ctx, types.NamespacedName{Name: getCACertName(r.ds), Namespace: OwnedObjectNamespace(r.ds)}, ca)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -42,35 +42,31 @@ func (r *ReconcileDiscoveryService) reconcileCA(ctx context.Context) (reconcile.
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileDiscoveryService) getCACertName() string {
-	return fmt.Sprintf("%s-%s", caCertSecretNamePrefix, r.ds.GetName())
+func getCACertName(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", caCertSecretNamePrefix, ds.GetName())
 }
 
-func (r *ReconcileDiscoveryService) getCACertCommonName() string {
-	return fmt.Sprintf("%s-%s", caCommonName, r.ds.GetName())
-}
-
-func (r *ReconcileDiscoveryService) getCACertNamespace() string {
-	return r.getNamespace()
+func getCACertCommonName(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", caCommonName, ds.GetName())
 }
 
 func (r *ReconcileDiscoveryService) genCACertObject() *operatorv1alpha1.DiscoveryServiceCertificate {
 
 	return &operatorv1alpha1.DiscoveryServiceCertificate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.getCACertName(),
-			Namespace: r.getCACertNamespace(),
+			Name:      getCACertName(r.ds),
+			Namespace: OwnedObjectNamespace(r.ds),
 		},
 		Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-			CommonName: r.getCACertCommonName(),
+			CommonName: getCACertCommonName(r.ds),
 			IsCA:       true,
 			ValidFor:   caValidFor,
 			Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 				SelfSigned: &operatorv1alpha1.SelfSignedConfig{},
 			},
 			SecretRef: corev1.SecretReference{
-				Name:      r.getCACertName(),
-				Namespace: r.getCACertNamespace(),
+				Name:      getCACertName(r.ds),
+				Namespace: OwnedObjectNamespace(r.ds),
 			},
 		},
 	}

--- a/pkg/controller/discoveryservice/cluster_role.go
+++ b/pkg/controller/discoveryservice/cluster_role.go
@@ -19,7 +19,7 @@ func (r *ReconcileDiscoveryService) reconcileClusterRole(ctx context.Context) (r
 
 	r.logger.V(1).Info("Reconciling CusterRole")
 	existent := &rbacv1.ClusterRole{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getName()}, existent)
+	err := r.client.Get(ctx, types.NamespacedName{Name: OwnedObjectName(r.ds)}, existent)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -52,7 +52,7 @@ func (r *ReconcileDiscoveryService) reconcileClusterRole(ctx context.Context) (r
 func (r *ReconcileDiscoveryService) genClusterRoleObject() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.getName(),
+			Name: OwnedObjectName(r.ds),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{

--- a/pkg/controller/discoveryservice/cluster_role_binding.go
+++ b/pkg/controller/discoveryservice/cluster_role_binding.go
@@ -17,7 +17,7 @@ func (r *ReconcileDiscoveryService) reconcileClusterRoleBinding(ctx context.Cont
 
 	r.logger.V(1).Info("Reconciling CusterRoleBinding")
 	existent := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getName()}, existent)
+	err := r.client.Get(ctx, types.NamespacedName{Name: OwnedObjectName(r.ds)}, existent)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -52,18 +52,18 @@ func (r *ReconcileDiscoveryService) genClusterRoleBindingObject() *rbacv1.Cluste
 
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.getName(),
+			Name: OwnedObjectName(r.ds),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
 			Kind:     "ClusterRole",
-			Name:     r.getName(),
+			Name:     OwnedObjectName(r.ds),
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      r.getName(),
-				Namespace: r.getNamespace(),
+				Name:      OwnedObjectName(r.ds),
+				Namespace: OwnedObjectNamespace(r.ds),
 			},
 		},
 	}

--- a/pkg/controller/discoveryservice/common.go
+++ b/pkg/controller/discoveryservice/common.go
@@ -2,24 +2,18 @@ package discoveryservice
 
 import (
 	"fmt"
+
+	operatorv1alpha1 "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
 )
 
-func (r *ReconcileDiscoveryService) getName() string {
-	return fmt.Sprintf("%s-%s", "marin3r", r.ds.GetName())
+func OwnedObjectName(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", "marin3r", ds.GetName())
 }
 
-func (r *ReconcileDiscoveryService) getNamespace() string {
-	return r.ds.Spec.DiscoveryServiceNamespace
+func OwnedObjectNamespace(ds *operatorv1alpha1.DiscoveryService) string {
+	return ds.Spec.DiscoveryServiceNamespace
 }
 
-func (r *ReconcileDiscoveryService) getAppLabel() string {
-	return fmt.Sprintf("%s-%s", "marin3r", r.ds.GetName())
-}
-
-func (r *ReconcileDiscoveryService) getDiscoveryServiceHost() string {
-	return fmt.Sprintf("%s.%s.%s", r.getName(), r.getNamespace(), "svc")
-}
-
-func (r *ReconcileDiscoveryService) getDiscoveryServicePort() uint32 {
-	return uint32(18000)
+func OwnedObjectAppLabel(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", "marin3r", ds.GetName())
 }

--- a/pkg/controller/discoveryservice/deployment.go
+++ b/pkg/controller/discoveryservice/deployment.go
@@ -1,196 +1,154 @@
 package discoveryservice
 
 import (
-	"context"
-
+	operatorv1alpha1 "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
+	"github.com/3scale/marin3r/pkg/reconcilers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
 	appLabelKey string = "app"
 )
 
-// reconcileDeployment is in charge of keeping the marin3r Deployment object in sync with the spec
-func (r *ReconcileDiscoveryService) reconcileDeployment(ctx context.Context) (reconcile.Result, error) {
+func deploymentGeneratorFn(ds *operatorv1alpha1.DiscoveryService) reconcilers.DeploymentGeneratorFn {
 
-	r.logger.V(1).Info("Reconciling Deployment")
-	existent := &appsv1.Deployment{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getName(), Namespace: r.getNamespace()}, existent)
+	return func() *appsv1.Deployment {
 
-	if err != nil {
-		if errors.IsNotFound(err) {
-			existent = r.getDeploymentObject()
-			if err := controllerutil.SetControllerReference(r.ds, existent, r.scheme); err != nil {
-				return reconcile.Result{}, err
-			}
-			if err := r.client.Create(ctx, existent); err != nil {
-				return reconcile.Result{}, err
-			}
-			r.logger.Info("Created Deployment")
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, err
-	}
-
-	// We just reconcile the spec for the moment
-	desired := r.getDeploymentObject()
-	// Avoid diff on fields not controlled by this controller
-	// NA
-
-	if !equality.Semantic.DeepEqual(existent.Spec, desired.Spec) {
-		patch := client.MergeFrom(existent.DeepCopy())
-		existent.Spec = desired.Spec
-		if err := r.client.Patch(ctx, existent, patch); err != nil {
-			return reconcile.Result{}, err
-		}
-		r.logger.Info("Patched Deployment")
-	}
-
-	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileDiscoveryService) getDeploymentObject() *appsv1.Deployment {
-
-	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.getName(),
-			Namespace: r.getNamespace(),
-			Labels:    map[string]string{appLabelKey: r.getAppLabel()},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32Ptr(1),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					appLabelKey: r.getAppLabel(),
-				},
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OwnedObjectName(ds),
+				Namespace: OwnedObjectNamespace(ds),
+				Labels:    map[string]string{appLabelKey: OwnedObjectAppLabel(ds)},
 			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					CreationTimestamp: metav1.Time{},
-					Labels:            map[string]string{appLabelKey: r.getAppLabel()},
-				},
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "server-cert",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName:  r.getServerCertName(),
-									DefaultMode: pointer.Int32Ptr(420),
-								},
-							},
-						},
-						{
-							// This won't work as the CA is in another namespace
-							// when using cert-manager issued certs. We need to
-							// sync the CA between namespaces.
-							Name: "ca-cert",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName:  r.getCACertName(),
-									DefaultMode: pointer.Int32Ptr(420),
-								},
-							},
-						},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						appLabelKey: OwnedObjectAppLabel(ds),
 					},
-					Containers: []corev1.Container{
-						{
-							Name:  "marin3r",
-							Image: r.ds.Spec.Image,
-							Args: []string{
-								"--certificate=/etc/marin3r/tls/server/tls.crt",
-								"--private-key=/etc/marin3r/tls/server/tls.key",
-								"--ca=/etc/marin3r/tls/ca/tls.crt",
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "discovery",
-									ContainerPort: 18000,
-									Protocol:      corev1.ProtocolTCP,
-								},
-								{
-									Name:          "webhook",
-									ContainerPort: 8443,
-									Protocol:      corev1.ProtocolTCP,
-								},
-								{
-									Name:          "metrics",
-									ContainerPort: 8383,
-									Protocol:      corev1.ProtocolTCP,
-								},
-								{
-									Name:          "cr-metrics",
-									ContainerPort: 8686,
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
-							Env: []corev1.EnvVar{
-								{Name: "WATCH_NAMESPACE", Value: ""},
-								{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										APIVersion: corev1.SchemeGroupVersion.Version,
-										FieldPath:  "metadata.name",
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Time{},
+						Labels:            map[string]string{appLabelKey: OwnedObjectAppLabel(ds)},
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: "server-cert",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName:  getServerCertName(ds),
+										DefaultMode: pointer.Int32Ptr(420),
 									},
-								}},
-							},
-							Resources: corev1.ResourceRequirements{},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "server-cert",
-									ReadOnly:  true,
-									MountPath: "/etc/marin3r/tls/server/",
-								},
-								{
-									Name:      "ca-cert",
-									ReadOnly:  true,
-									MountPath: "/etc/marin3r/tls/ca/",
 								},
 							},
-							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-							ImagePullPolicy:          corev1.PullIfNotPresent,
+							{
+								// This won't work as the CA is in another namespace
+								// when using cert-manager issued certs. We need to
+								// sync the CA between namespaces.
+								Name: "ca-cert",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName:  getCACertName(ds),
+										DefaultMode: pointer.Int32Ptr(420),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name:  "marin3r",
+								Image: ds.Spec.Image,
+								Args: []string{
+									"--certificate=/etc/marin3r/tls/server/tls.crt",
+									"--private-key=/etc/marin3r/tls/server/tls.key",
+									"--ca=/etc/marin3r/tls/ca/tls.crt",
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "discovery",
+										ContainerPort: 18000,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "webhook",
+										ContainerPort: 8443,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "metrics",
+										ContainerPort: 8383,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "cr-metrics",
+										ContainerPort: 8686,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								Env: []corev1.EnvVar{
+									{Name: "WATCH_NAMESPACE", Value: ""},
+									{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: corev1.SchemeGroupVersion.Version,
+											FieldPath:  "metadata.name",
+										},
+									}},
+								},
+								Resources: corev1.ResourceRequirements{},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "server-cert",
+										ReadOnly:  true,
+										MountPath: "/etc/marin3r/tls/server/",
+									},
+									{
+										Name:      "ca-cert",
+										ReadOnly:  true,
+										MountPath: "/etc/marin3r/tls/ca/",
+									},
+								},
+								TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+								TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+								ImagePullPolicy:          corev1.PullIfNotPresent,
+							},
+						},
+						RestartPolicy:                 corev1.RestartPolicyAlways,
+						TerminationGracePeriodSeconds: pointer.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
+						DNSPolicy:                     corev1.DNSClusterFirst,
+						ServiceAccountName:            OwnedObjectName(ds),
+						DeprecatedServiceAccount:      OwnedObjectName(ds),
+						SecurityContext:               &corev1.PodSecurityContext{},
+						SchedulerName:                 corev1.DefaultSchedulerName,
+					},
+				},
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: "25%",
+						},
+						MaxSurge: &intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: "25%",
 						},
 					},
-					RestartPolicy:                 corev1.RestartPolicyAlways,
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
-					DNSPolicy:                     corev1.DNSClusterFirst,
-					ServiceAccountName:            r.getName(),
-					DeprecatedServiceAccount:      r.getName(),
-					SecurityContext:               &corev1.PodSecurityContext{},
-					SchedulerName:                 corev1.DefaultSchedulerName,
 				},
+				RevisionHistoryLimit:    pointer.Int32Ptr(10),
+				ProgressDeadlineSeconds: pointer.Int32Ptr(600),
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.String,
-						StrVal: "25%",
-					},
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.String,
-						StrVal: "25%",
-					},
-				},
-			},
-			RevisionHistoryLimit:    pointer.Int32Ptr(10),
-			ProgressDeadlineSeconds: pointer.Int32Ptr(600),
-		},
-	}
+		}
 
-	if r.ds.Spec.Debug {
-		dep.Spec.Template.Spec.Containers[0].Args = append(dep.Spec.Template.Spec.Containers[0].Args, "--zap-devel")
-	}
+		if ds.Spec.Debug {
+			dep.Spec.Template.Spec.Containers[0].Args = append(dep.Spec.Template.Spec.Containers[0].Args, "--zap-devel")
+		}
 
-	return dep
+		return dep
+	}
 }

--- a/pkg/controller/discoveryservice/discoveryservice_controller.go
+++ b/pkg/controller/discoveryservice/discoveryservice_controller.go
@@ -247,10 +247,6 @@ func (r *ReconcileDiscoveryService) Reconcile(request reconcile.Request) (reconc
 		return result, err
 	}
 
-	// result, err = r.reconcileDeployment(ctx)
-	// if result.Requeue || err != nil {
-	// 	return result, err
-	// }
 	dr := reconcilers.NewDeploymentReconciler(ctx, r.logger, r.client, r.scheme, r.ds)
 	result, err = dr.Reconcile(
 		types.NamespacedName{Name: OwnedObjectName(r.ds), Namespace: OwnedObjectNamespace(r.ds)},

--- a/pkg/controller/discoveryservice/discoveryservice_controller.go
+++ b/pkg/controller/discoveryservice/discoveryservice_controller.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/3scale/marin3r/pkg/apis/external"
 	operatorv1alpha1 "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
+	"github.com/3scale/marin3r/pkg/reconcilers"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -245,7 +247,15 @@ func (r *ReconcileDiscoveryService) Reconcile(request reconcile.Request) (reconc
 		return result, err
 	}
 
-	result, err = r.reconcileDeployment(ctx)
+	// result, err = r.reconcileDeployment(ctx)
+	// if result.Requeue || err != nil {
+	// 	return result, err
+	// }
+	dr := reconcilers.NewDeploymentReconciler(ctx, r.logger, r.client, r.scheme, r.ds)
+	result, err = dr.Reconcile(
+		types.NamespacedName{Name: OwnedObjectName(r.ds), Namespace: OwnedObjectNamespace(r.ds)},
+		deploymentGeneratorFn(r.ds),
+	)
 	if result.Requeue || err != nil {
 		return result, err
 	}

--- a/pkg/controller/discoveryservice/discoveryservice_controller.go
+++ b/pkg/controller/discoveryservice/discoveryservice_controller.go
@@ -9,9 +9,11 @@ import (
 	operatorv1alpha1 "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
 	"github.com/3scale/marin3r/pkg/reconcilers"
 	"github.com/go-logr/logr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -127,8 +129,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for Namespace resources owned by the DiscoveryService resource
-	err = c.Watch(&source.Kind{Type: &corev1.Namespace{}}, &handler.EnqueueRequestForOwner{
+	// Watch for MutatingAdmissonConfiguration resources owned by the DiscoveryService resource
+	err = c.Watch(&source.Kind{Type: &admissionregistrationv1.MutatingWebhookConfiguration{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &operatorv1alpha1.DiscoveryService{},
 	})

--- a/pkg/controller/discoveryservice/enabled_namespaces.go
+++ b/pkg/controller/discoveryservice/enabled_namespaces.go
@@ -323,11 +323,6 @@ func getEnvoyBootstrapConfig(host string, port uint32) (string, error) {
 		return "", err
 	}
 
-	// yaml, err := yaml.JSONToYAML(json.Bytes())
-	// if err != nil {
-	// 	return "", err
-	// }
-
 	return string(json.Bytes()), nil
 }
 

--- a/pkg/controller/discoveryservice/enabled_namespaces.go
+++ b/pkg/controller/discoveryservice/enabled_namespaces.go
@@ -181,7 +181,7 @@ func (r *ReconcileDiscoveryService) getClientCertObject(namespace string) *opera
 			Namespace: namespace,
 		},
 		Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-			CommonName: r.getName(),
+			CommonName: OwnedObjectName(r.ds),
 			ValidFor:   clientValidFor,
 			Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 				CertManager: &operatorv1alpha1.CertManagerConfig{
@@ -198,7 +198,7 @@ func (r *ReconcileDiscoveryService) getClientCertObject(namespace string) *opera
 
 func (r *ReconcileDiscoveryService) getBootstrapConfigMapObject(namespace string) (*corev1.ConfigMap, error) {
 
-	config, err := getEnvoyBootstrapConfig(r.getDiscoveryServiceHost(), r.getDiscoveryServicePort())
+	config, err := getEnvoyBootstrapConfig(getDiscoveryServiceHost(r.ds), getDiscoveryServicePort())
 	if err != nil {
 		return nil, err
 	}
@@ -329,4 +329,12 @@ func getEnvoyBootstrapConfig(host string, port uint32) (string, error) {
 	// }
 
 	return string(json.Bytes()), nil
+}
+
+func getDiscoveryServiceHost(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s.%s.%s", OwnedObjectName(ds), OwnedObjectNamespace(ds), "svc")
+}
+
+func getDiscoveryServicePort() uint32 {
+	return uint32(18000)
 }

--- a/pkg/controller/discoveryservice/mutating_webhook_config.go
+++ b/pkg/controller/discoveryservice/mutating_webhook_config.go
@@ -118,9 +118,18 @@ func (r *ReconcileDiscoveryService) genMutatingWebhookConfigurationObject(caBund
 						Name:      OwnedObjectName(r.ds),
 						Namespace: OwnedObjectNamespace(r.ds),
 						Path:      pointer.StringPtr(webhook.MutatePath),
+						Port:      pointer.Int32Ptr(443),
 					},
 					CABundle: caBundle,
 				},
+				MatchPolicy: func() *admissionregistrationv1.MatchPolicyType {
+					s := admissionregistrationv1.Equivalent
+					return &s
+				}(),
+				ReinvocationPolicy: func() *admissionregistrationv1.ReinvocationPolicyType {
+					s := admissionregistrationv1.NeverReinvocationPolicy
+					return &s
+				}(),
 			},
 		},
 	}

--- a/pkg/controller/discoveryservice/mutating_webhook_config.go
+++ b/pkg/controller/discoveryservice/mutating_webhook_config.go
@@ -126,10 +126,6 @@ func (r *ReconcileDiscoveryService) genMutatingWebhookConfigurationObject(caBund
 	}
 }
 
-// func (r *ReconcileDiscoveryService) getMutatingWebhookName() string {
-// 	return fmt.Sprintf("%s-%s", MutatingWebhookPrefix, r.ds.GetName())
-// }
-
 func (r *ReconcileDiscoveryService) getCABundle(ctx context.Context) ([]byte, error) {
 
 	secret := &corev1.Secret{}

--- a/pkg/controller/discoveryservice/mutating_webhook_config.go
+++ b/pkg/controller/discoveryservice/mutating_webhook_config.go
@@ -33,7 +33,7 @@ func (r *ReconcileDiscoveryService) reconcileMutatingWebhook(ctx context.Context
 	}
 
 	existent := &admissionregistrationv1.MutatingWebhookConfiguration{}
-	err = r.client.Get(ctx, types.NamespacedName{Name: r.getName()}, existent)
+	err = r.client.Get(ctx, types.NamespacedName{Name: OwnedObjectName(r.ds)}, existent)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -69,7 +69,7 @@ func (r *ReconcileDiscoveryService) genMutatingWebhookConfigurationObject(caBund
 
 	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.getName(),
+			Name: OwnedObjectName(r.ds),
 		},
 		Webhooks: []admissionregistrationv1.MutatingWebhook{
 			{
@@ -115,8 +115,8 @@ func (r *ReconcileDiscoveryService) genMutatingWebhookConfigurationObject(caBund
 				},
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
-						Name:      r.getName(),
-						Namespace: r.getNamespace(),
+						Name:      OwnedObjectName(r.ds),
+						Namespace: OwnedObjectNamespace(r.ds),
 						Path:      pointer.StringPtr(webhook.MutatePath),
 					},
 					CABundle: caBundle,
@@ -133,7 +133,7 @@ func (r *ReconcileDiscoveryService) genMutatingWebhookConfigurationObject(caBund
 func (r *ReconcileDiscoveryService) getCABundle(ctx context.Context) ([]byte, error) {
 
 	secret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: r.getCACertName(), Namespace: r.getNamespace()}, secret); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Name: getCACertName(r.ds), Namespace: OwnedObjectNamespace(r.ds)}, secret); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/discoveryservice/server_certificate.go
+++ b/pkg/controller/discoveryservice/server_certificate.go
@@ -24,7 +24,7 @@ func (r *ReconcileDiscoveryService) reconcileServerCertificate(ctx context.Conte
 	r.logger.V(1).Info("Reconciling server certificate")
 
 	cert := &operatorv1alpha1.DiscoveryServiceCertificate{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getServerCertName(), Namespace: r.getNamespace()}, cert)
+	err := r.client.Get(ctx, types.NamespacedName{Name: getServerCertName(r.ds), Namespace: OwnedObjectNamespace(r.ds)}, cert)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -48,23 +48,22 @@ func (r *ReconcileDiscoveryService) reconcileServerCertificate(ctx context.Conte
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileDiscoveryService) getServerCertName() string {
-	return fmt.Sprintf("%s-%s", serverCertSecretNamePrefix, r.ds.GetName())
+func getServerCertName(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", serverCertSecretNamePrefix, ds.GetName())
 }
 
-// TODO: CN is wrong
-func (r *ReconcileDiscoveryService) getServerCertCommonName() string {
-	return fmt.Sprintf("%s-%s", caCommonName, r.ds.GetName())
+func getServerCertCommonName(ds *operatorv1alpha1.DiscoveryService) string {
+	return fmt.Sprintf("%s-%s", caCommonName, ds.GetName())
 }
 
 func (r *ReconcileDiscoveryService) getServerCertObject() *operatorv1alpha1.DiscoveryServiceCertificate {
 	return &operatorv1alpha1.DiscoveryServiceCertificate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.getServerCertName(),
-			Namespace: r.getNamespace(),
+			Name:      getServerCertName(r.ds),
+			Namespace: OwnedObjectNamespace(r.ds),
 		},
 		Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-			CommonName:          r.getServerCertCommonName(),
+			CommonName:          getServerCertCommonName(r.ds),
 			IsServerCertificate: true,
 			ValidFor:            serverValidFor,
 			Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
@@ -72,10 +71,10 @@ func (r *ReconcileDiscoveryService) getServerCertObject() *operatorv1alpha1.Disc
 					ClusterIssuer: r.getClusterIssuerName(),
 				},
 			},
-			Hosts: []string{r.getDiscoveryServiceHost()},
+			Hosts: []string{getDiscoveryServiceHost(r.ds)},
 			SecretRef: corev1.SecretReference{
-				Name:      r.getServerCertName(),
-				Namespace: r.getNamespace(),
+				Name:      getServerCertName(r.ds),
+				Namespace: OwnedObjectNamespace(r.ds),
 			},
 		},
 	}

--- a/pkg/controller/discoveryservice/service.go
+++ b/pkg/controller/discoveryservice/service.go
@@ -18,7 +18,7 @@ func (r *ReconcileDiscoveryService) reconcileService(ctx context.Context) (recon
 
 	r.logger.V(1).Info("Reconciling Service")
 	existent := &corev1.Service{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getName(), Namespace: r.getNamespace()}, existent)
+	err := r.client.Get(ctx, types.NamespacedName{Name: OwnedObjectName(r.ds), Namespace: OwnedObjectNamespace(r.ds)}, existent)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -55,12 +55,12 @@ func (r *ReconcileDiscoveryService) genServiceObject() *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.getName(),
-			Namespace: r.getNamespace(),
+			Name:      OwnedObjectName(r.ds),
+			Namespace: OwnedObjectNamespace(r.ds),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,
-			Selector:        map[string]string{appLabelKey: r.getAppLabel()},
+			Selector:        map[string]string{appLabelKey: OwnedObjectAppLabel(r.ds)},
 			SessionAffinity: corev1.ServiceAffinityNone,
 			Ports: []corev1.ServicePort{
 				{

--- a/pkg/controller/discoveryservice/service_account.go
+++ b/pkg/controller/discoveryservice/service_account.go
@@ -15,7 +15,7 @@ func (r *ReconcileDiscoveryService) reconcileServiceAccount(ctx context.Context)
 
 	r.logger.V(1).Info("Reconciling ServiceAccount")
 	existent := &corev1.ServiceAccount{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: r.getName(), Namespace: r.getNamespace()}, existent)
+	err := r.client.Get(ctx, types.NamespacedName{Name: OwnedObjectName(r.ds), Namespace: OwnedObjectNamespace(r.ds)}, existent)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -40,8 +40,8 @@ func (r *ReconcileDiscoveryService) reconcileServiceAccount(ctx context.Context)
 func (r *ReconcileDiscoveryService) genServiceAccountObject() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.getName(),
-			Namespace: r.getNamespace(),
+			Name:      OwnedObjectName(r.ds),
+			Namespace: OwnedObjectNamespace(r.ds),
 		},
 	}
 }

--- a/pkg/controller/discoveryservice/signer.go
+++ b/pkg/controller/discoveryservice/signer.go
@@ -90,7 +90,7 @@ func (r *ReconcileDiscoveryService) getClusterIssuerObject() *certmanagerv1alpha
 		Spec: certmanagerv1alpha2.IssuerSpec{
 			IssuerConfig: certmanagerv1alpha2.IssuerConfig{
 				CA: &certmanagerv1alpha2.CAIssuer{
-					SecretName: r.getCACertName(),
+					SecretName: getCACertName(r.ds),
 				},
 			},
 		},
@@ -104,8 +104,8 @@ func (r *ReconcileDiscoveryService) syncCASecret(ctx context.Context) error {
 	// Get the CA secret
 	secret := &corev1.Secret{}
 	err := r.client.Get(ctx, types.NamespacedName{
-		Name:      r.getCACertName(),
-		Namespace: r.getNamespace(),
+		Name:      getCACertName(r.ds),
+		Namespace: OwnedObjectNamespace(r.ds),
 	}, secret)
 	if err != nil {
 		return err
@@ -114,14 +114,14 @@ func (r *ReconcileDiscoveryService) syncCASecret(ctx context.Context) error {
 	// Get the synced secret
 	syncedSecret := &corev1.Secret{}
 	err = r.client.Get(ctx, types.NamespacedName{
-		Name:      r.getCACertName(),
+		Name:      getCACertName(r.ds),
 		Namespace: r.ds.Spec.Signer.CertManager.Namespace,
 	}, syncedSecret)
 
 	if err != nil {
 
 		if errors.IsNotFound(err) {
-			syncedSecret.SetName(r.getCACertName())
+			syncedSecret.SetName(getCACertName(r.ds))
 			syncedSecret.SetNamespace(r.ds.Spec.Signer.CertManager.Namespace)
 			syncedSecret.Data = secret.Data
 			if err := controllerutil.SetControllerReference(r.ds, syncedSecret, r.scheme); err != nil {

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -1,0 +1,132 @@
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/3scale/marin3r/pkg/common"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// DeploymentGeneratorFn is a function that when called returns an appsv1.Deployment object
+type DeploymentGeneratorFn func() *appsv1.Deployment
+
+// DeploymentReconciler is a generic Deployment reconciler
+type DeploymentReconciler struct {
+	ctx    context.Context
+	logger logr.Logger
+	client client.Client
+	scheme *runtime.Scheme
+	owner  metav1.Object
+}
+
+// NewDeploymentReconciler returns a new DeploymentReconciler object
+func NewDeploymentReconciler(ctx context.Context, logger logr.Logger, client client.Client,
+	scheme *runtime.Scheme, owner metav1.Object) DeploymentReconciler {
+	return DeploymentReconciler{
+		ctx:    ctx,
+		logger: logger,
+		client: client,
+		scheme: scheme,
+		owner:  owner,
+	}
+}
+
+// Reconcile reconciles the Deployment object using the given generator
+func (r *DeploymentReconciler) Reconcile(o types.NamespacedName, generatorFn DeploymentGeneratorFn) (reconcile.Result, error) {
+
+	r.logger.V(1).Info("Reconciling Deployment")
+	deployment := &appsv1.Deployment{}
+	err := r.client.Get(r.ctx, types.NamespacedName{Name: o.Name, Namespace: o.Namespace}, deployment)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.logger.V(1).Info("Deployment not found")
+			deployment := generatorFn()
+			if err := controllerutil.SetControllerReference(r.owner, deployment, r.scheme); err != nil {
+				return reconcile.Result{}, err
+			}
+			if err := r.client.Create(r.ctx, deployment); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.logger.Info("Created Deployment")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	var updated bool = false
+	desired := generatorFn()
+
+	tmpUpdated, err := r.reconcileSpec(deployment, desired)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	updated = updated || tmpUpdated
+
+	tmpUpdated, err = r.reconcileLabels(deployment, desired)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	updated = updated || tmpUpdated
+
+	if updated {
+		if err := r.client.Update(r.ctx, deployment); err != nil {
+			return reconcile.Result{}, err
+		}
+		r.logger.Info("Deployment Updated")
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *DeploymentReconciler) reconcileSpec(existentObj, desiredObj common.KubernetesObject) (bool, error) {
+	existent, ok := existentObj.(*appsv1.Deployment)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *appsv1.Deployment", existentObj)
+	}
+	desired, ok := desiredObj.(*appsv1.Deployment)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *appsv1.Deployment", desiredObj)
+	}
+
+	updated := false
+
+	if !equality.Semantic.DeepEqual(existent.Spec, desired.Spec) {
+		r.logger.V(1).Info("Deployment spec needs reconcile")
+		existent.Spec = desired.Spec
+		updated = true
+	}
+
+	return updated, nil
+}
+
+func (r *DeploymentReconciler) reconcileLabels(existentObj, desiredObj common.KubernetesObject) (bool, error) {
+	existent, ok := existentObj.(*appsv1.Deployment)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *appsv1.Deployment", existentObj)
+	}
+	desired, ok := desiredObj.(*appsv1.Deployment)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *appsv1.Deployment", desiredObj)
+	}
+
+	updated := false
+
+	if !equality.Semantic.DeepEqual(existent.GetLabels(), desired.GetLabels()) {
+		r.logger.V(1).Info("Deployment labels need reconcile")
+		existent.ObjectMeta.Labels = desired.GetLabels()
+		updated = true
+	}
+
+	return updated, nil
+}

--- a/pkg/reconcilers/deployment_test.go
+++ b/pkg/reconcilers/deployment_test.go
@@ -1,0 +1,344 @@
+package reconcilers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/3scale/marin3r/pkg/common"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestNewDeploymentReconciler(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		logger logr.Logger
+		client client.Client
+		scheme *runtime.Scheme
+		owner  metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want DeploymentReconciler
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewDeploymentReconciler(tt.args.ctx, tt.args.logger, tt.args.client, tt.args.scheme, tt.args.owner); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewDeploymentReconciler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeploymentReconciler_Reconcile(t *testing.T) {
+
+	var generatorFn DeploymentGeneratorFn = func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aaaa",
+				Namespace: "aaaa",
+				Labels: map[string]string{
+					"key1": "value1",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"key1": "value1"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Time{},
+						Labels:            map[string]string{"key1": "value1"},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+		}
+	}
+
+	t.Run("Creates a new Deployment", func(t *testing.T) {
+		r := DeploymentReconciler{
+			ctx:    context.TODO(),
+			logger: logf.Log.WithName("test"),
+			client: fake.NewFakeClient(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aaaa",
+					Namespace: "aaaa",
+				},
+				Spec: appsv1.DeploymentSpec{},
+			}),
+			scheme: scheme.Scheme,
+			owner:  &appsv1.Deployment{}, // this is irrelevant for this tests
+		}
+
+		result, err := r.Reconcile(
+			types.NamespacedName{Name: "aaaa", Namespace: "aaaa"},
+			generatorFn,
+		)
+		if err != nil {
+			t.Errorf("DeploymentReconciler.Reconcile() error = %v", err)
+			return
+		}
+		wantResult := reconcile.Result{}
+		if result != wantResult {
+			t.Errorf("DeploymentReconciler.Reconcile() bad result. Got %v, wanted %v", result, wantResult)
+			return
+		}
+		gotDep := &appsv1.Deployment{}
+		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "aaaa", Namespace: "aaaa"}, gotDep); err != nil {
+			t.Errorf("DeploymentReconciler.Reconcile() Deployment does not exist")
+			return
+		}
+
+		if *gotDep.Spec.Replicas != *generatorFn().Spec.Replicas {
+			t.Errorf("DeploymentReconciler.Reconcile() spec does not match desired one")
+		}
+	})
+
+	t.Run("Updates a Deployment", func(t *testing.T) {
+		r := DeploymentReconciler{
+			ctx:    context.TODO(),
+			logger: logf.Log.WithName("test"),
+			client: fake.NewFakeClient(),
+			scheme: scheme.Scheme,
+			owner:  &appsv1.Deployment{}, // this is irrelevant for this tests
+		}
+
+		result, err := r.Reconcile(
+			types.NamespacedName{Name: "aaaa", Namespace: "aaaa"},
+			generatorFn,
+		)
+		if err != nil {
+			t.Errorf("DeploymentReconciler.Reconcile() error = %v", err)
+			return
+		}
+		wantResult := reconcile.Result{}
+		if result != wantResult {
+			t.Errorf("DeploymentReconciler.Reconcile() bad rsult. Got %v, wanted %v", result, wantResult)
+			return
+		}
+		gotDep := &appsv1.Deployment{}
+		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "aaaa", Namespace: "aaaa"}, gotDep); err != nil {
+			t.Errorf("DeploymentReconciler.Reconcile() Deployment was not created")
+		}
+	})
+
+}
+
+func TestDeploymentReconciler_reconcileDeployment(t *testing.T) {
+	type args struct {
+		existentObj common.KubernetesObject
+		desiredObj  common.KubernetesObject
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Labels match desired labels after reconcile",
+			args: args{
+				existentObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+				desiredObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Spec matches desired spec after reconcile",
+			args: args{
+				existentObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+				desiredObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(2),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "False is returned when no changes required",
+			args: args{
+				existentObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+				desiredObj: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aaaa",
+						Namespace: "aaaa",
+						Labels: map[string]string{
+							"key1": "value1",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"key1": "value1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								CreationTimestamp: metav1.Time{},
+								Labels:            map[string]string{"key1": "value1"},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			existent := tt.args.existentObj.(*appsv1.Deployment)
+			desired := tt.args.desiredObj.(*appsv1.Deployment)
+
+			r := DeploymentReconciler{
+				ctx:    context.TODO(),
+				logger: logf.Log.WithName("test"),
+				client: fake.NewFakeClient(existent),
+				scheme: scheme.Scheme,
+				owner:  &appsv1.Deployment{}, // this is irrelevant for this tests
+			}
+
+			got, err := r.reconcileDeployment(tt.args.existentObj, tt.args.desiredObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeploymentReconciler.reconcileDeployment() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("DeploymentReconciler.reconcileDeployment() = %v, want %v", got, tt.want)
+				return
+			}
+
+			// Check labels match
+			if !equality.Semantic.DeepEqual(existent.GetLabels(), desired.GetLabels()) {
+				t.Errorf("DeploymentReconciler.reconcileDeployment() ObjectMeta.Labels don't match. Got %v, want %v", existent.GetLabels(), desired.GetLabels())
+			}
+			// Check Spec matches
+			if !equality.Semantic.DeepEqual(existent.Spec, desired.Spec) {
+				t.Errorf("DeploymentReconciler.reconcileDeployment() Spec don't match. Got %v, want %v", existent.Spec, desired.Spec)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Create a generic Deployment reconciler that can be used from several controllers. Also fix a bug detected in the reconciliation of the MutatingWebhookConfiguration.