### PR TITLE
Fix an openshift bug in the webhook by changing certificate signing to rsa

### DIFF
--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/jetstack/cert-manager/pkg/util/errors"
 )
 
+// LoadX509Certificate loads a x509.Certificate object from the given bytes
 func LoadX509Certificate(cert []byte) (*x509.Certificate, error) {
 
 	cpb, _ := pem.Decode(cert)
@@ -42,7 +42,7 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	case "PRIVATE KEY":
 		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
-			return nil, errors.NewInvalidData("error parsing pkcs#8 private key: %s", err.Error())
+			return nil, fmt.Errorf("error parsing pkcs#8 private key: %s", err.Error())
 		}
 
 		signer, ok := key.(crypto.Signer)
@@ -53,12 +53,12 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	case "RSA PRIVATE KEY":
 		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
-			return nil, errors.NewInvalidData("error parsing rsa private key: %s", err.Error())
+			return nil, fmt.Errorf("error parsing rsa private key: %s", err.Error())
 		}
 
 		err = key.Validate()
 		if err != nil {
-			return nil, errors.NewInvalidData("rsa private key failed validation: %s", err.Error())
+			return nil, fmt.Errorf("rsa private key failed validation: %s", err.Error())
 		}
 		return key, nil
 
@@ -67,6 +67,7 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	}
 }
 
+// LoadCA reads a CA certificate and loads it into a CertPool object
 func LoadCA(caPath string, logger logr.Logger) *x509.CertPool {
 	certPool := x509.NewCertPool()
 	if bs, err := ioutil.ReadFile(caPath); err != nil {
@@ -82,6 +83,7 @@ func LoadCA(caPath string, logger logr.Logger) *x509.CertPool {
 	return certPool
 }
 
+// GeneratePrivateKey generates a new RSA private key
 func GeneratePrivateKey() (*rsa.PrivateKey, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -90,6 +92,8 @@ func GeneratePrivateKey() (*rsa.PrivateKey, error) {
 	return priv, nil
 }
 
+// GenerateCertificate issues a new certificate with the passed options and signed by the parent certificate if one is given. A self-signed
+// is issued otherwise.
 func GenerateCertificate(issuerCert *x509.Certificate, signerKey interface{}, commonName string, validFor time.Duration, isServer, isCA bool, host ...string) ([]byte, []byte, error) {
 
 	priv, err := GeneratePrivateKey()


### PR DESCRIPTION
For some reason the webhook fails (api server cpmplains about tls handshake error) in openshift 4.3 if certificates are signed using ECDSA 256. Changing to RSA 2048 fixes the problem.