### PR TITLE
fix/filter-out-secret-deletions

### DIFF
--- a/pkg/controller/discoveryservice/discoveryservice_controller.go
+++ b/pkg/controller/discoveryservice/discoveryservice_controller.go
@@ -148,6 +148,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			}
 			return false
 		},
+		DeleteFunc: func(e event.DeleteEvent) bool { return false },
 	}
 	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, filter)
 	if err != nil {


### PR DESCRIPTION
By mistake, the DiscoveryService controller is watching for all Secret objects deletions and running unnecesary reconcile loops. This PR filters out all Secret deletion events, which are of no interest for the controller.