### PR TITLE
Regenerate manifests using controller-gen v0.3.0

### DIFF
--- a/config/crd/bases/envoy.marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/config/crd/bases/envoy.marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: envoyconfigrevisions.envoy.marin3r.3scale.net
 spec:

--- a/config/crd/bases/envoy.marin3r.3scale.net_envoyconfigs.yaml
+++ b/config/crd/bases/envoy.marin3r.3scale.net_envoyconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: envoyconfigs.envoy.marin3r.3scale.net
 spec:

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: discoveryservicecertificates.operator.marin3r.3scale.net
 spec:

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: discoveryservices.operator.marin3r.3scale.net
 spec:


### PR DESCRIPTION
controller-gen v0.3.0, intended to be used with
operator-sdk v1.1.0 introduces formatting changes.
This commit regenerates the manifests to include
the regeneration of manifests with this controller-gen
version to be consistent with it.