### PR TITLE
Add configurable resource requirements for DiscoveryService

### DIFF
--- a/apis/operator/v1alpha1/discoveryservice_types.go
+++ b/apis/operator/v1alpha1/discoveryservice_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"github.com/operator-framework/operator-lib/status"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,6 +49,12 @@ type DiscoveryServiceSpec struct {
 	// use since secret data is never shown in the logs.
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Debug bool `json:"debug,omitempty"`
+	// Resources holds the Resource Requirements to use for the discovery service
+	// Deployment. When not set it defaults to no resource requests nor limits.
+	// CPU and Memory resources are supported.
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // DiscoveryServiceStatus defines the observed state of DiscoveryService
@@ -74,6 +81,17 @@ type DiscoveryService struct {
 
 	Spec   DiscoveryServiceSpec   `json:"spec,omitempty"`
 	Status DiscoveryServiceStatus `json:"status,omitempty"`
+}
+
+func (d *DiscoveryService) Resources() corev1.ResourceRequirements {
+	if d.Spec.Resources == nil {
+		return d.defaultDeploymentResources()
+	}
+	return *d.Spec.Resources
+}
+
+func (d *DiscoveryService) defaultDeploymentResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{}
 }
 
 // +kubebuilder:object:root=true

--- a/apis/operator/v1alpha1/discoveryservice_types_test.go
+++ b/apis/operator/v1alpha1/discoveryservice_types_test.go
@@ -1,0 +1,54 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestDiscoveryServiceResources(t *testing.T) {
+	explicitelySetResources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("200Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("200m"),
+			v1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+	}
+
+	cases := []struct {
+		testName                string
+		discoveryServiceFactory func() *DiscoveryService
+		expectedResult          v1.ResourceRequirements
+	}{
+		{"With default Resources",
+			func() *DiscoveryService {
+				return &DiscoveryService{}
+			},
+			v1.ResourceRequirements{},
+		},
+		{"With explicitely set Resources",
+			func() *DiscoveryService {
+				return &DiscoveryService{
+					Spec: DiscoveryServiceSpec{
+						Resources: explicitelySetResources,
+					},
+				}
+			},
+			*explicitelySetResources,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			receivedResult := tc.discoveryServiceFactory().Resources()
+			if !equality.Semantic.DeepEqual(tc.expectedResult, receivedResult) {
+				subT.Errorf("Expected result differs: Expected: %v, Received: %v", tc.expectedResult, receivedResult)
+			}
+		})
+	}
+}

--- a/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	"github.com/operator-framework/operator-lib/status"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -255,6 +256,11 @@ func (in *DiscoveryServiceSpec) DeepCopyInto(out *DiscoveryServiceSpec) {
 		in, out := &in.EnabledNamespaces, &out.EnabledNamespaces
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -58,6 +58,34 @@ spec:
               description: Image holds the image to use for the discovery service
                 Deployment
               type: string
+            resources:
+              description: Resources holds the Resource Requirements to use for the
+                discovery service Deployment. When not set it defaults to no resource
+                requests nor limits. CPU and Memory resources are supported.
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
           required:
           - discoveryServiceNamespace
           - image

--- a/controllers/operator/deployment.go
+++ b/controllers/operator/deployment.go
@@ -95,7 +95,7 @@ func deploymentGeneratorFn(ds *operatorv1alpha1.DiscoveryService, secret *corev1
 										},
 									}},
 								},
-								Resources: corev1.ResourceRequirements{},
+								Resources: ds.Resources(),
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      "server-cert",

--- a/docs/api-reference/reference.asciidoc
+++ b/docs/api-reference/reference.asciidoc
@@ -463,6 +463,7 @@ DiscoveryServiceSpec defines the desired state of DiscoveryService
 | *`enabledNamespaces`* __string array__ | EnabledNamespaces is a list of namespaces where the envoy discovery service is enabled. In order to be able to use marin3r from a given namespace its name needs to be included in this list because the operator needs to add some required resources in that namespace.
 | *`image`* __string__ | Image holds the image to use for the discovery service Deployment
 | *`debug`* __boolean__ | Debug enables debugging log level for the discovery service controllers. It is safe to use since secret data is never shown in the logs.
+| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | Resources holds the Resource Requirements to use for the discovery service Deployment. When not set it defaults to no resource requests nor limits. CPU and Memory resources are supported.
 |===
 
 


### PR DESCRIPTION
Hi,

This PR adds configurable resource requests and limits for the `DiscoveryService` deployment through the `DiscoveryService` custom resource.

Some decisions:
* By default, if no resources are provided no resource requests and limits are set (as before this PR)

Some behavior details:
* In Kubernetes two different quantities can be semantically equal. For example, for CPU `1000m` and `1` are equivalent. In this case in the deployment it's always converted to `1`. The implementation performs semantic comparison so if 1 is set in the `DiscoveryService` cpu resource request, and then 1000m is set, NO difference is detected at the Deployment level (and thus, a redeploy of the Deployment is not triggered).

Pending:

- [x] Testing
- [x] Documentation