### PR TITLE
Makefile: Add kuttl as a prerequisite of e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ TETS_ARTIFACTS_DIR ?= tmp/test
 $(TETS_ARTIFACTS_DIR):
 	mkdir -p $(TETS_ARTIFACTS_DIR)
 
-e2e: tmp manifests docker-build $(TEST_OPERATOR_MANIFEST)
+e2e: $(KUTTL) tmp manifests docker-build $(TEST_OPERATOR_MANIFEST)
 	$(KUTTL) test
 
 #########################3333333333#########


### PR DESCRIPTION
If a user didn't previously have bin/kuttl installed the e2e target failed due to needing that command.

This PR adds kuttl as a prerequisite of the e2e target.