### PR TITLE
Makefile: Add target to get crd-ref-docs locally to the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,14 @@ grpc-proxy: certs
 #### refdocs generation ####
 ############################
 
-refdocs: ## Generates api reference documentation from code. Requires https://github.com/elastic/crd-ref-docs binary to be present in the PATH
+CRD_REFDOCS_VERSION := v0.0.5
+CRD_REFDOCS := bin/crd-ref-docs
+$(CRD_REFDOCS):
+		mkdir -p $$(dirname $@)
+		curl -sLo $(CRD_REFDOCS) https://github.com/elastic/crd-ref-docs/releases/download/$(CRD_REFDOCS_VERSION)/crd-ref-docs
+		chmod +x $(CRD_REFDOCS)
+
+refdocs: $(CRD_REFDOCS) ## Generates api reference documentation from code
 	crd-ref-docs \
 		--source-path=apis \
 		--config=docs/api-reference/config.yaml \


### PR DESCRIPTION
This PR adds the ability to get the `crd-ref-docs` binary to generate the CRD documentation as a Makefile target.

This new target has also been added as a prerequisite of the `refdoc` target.

With this, a user does not need to manually download the `crd-ref-docs` binary to be able to generate the documentation