### PR TITLE
Add configurable resource requirements for Envoy sidecar in Webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@ The marin3r mutating admission webhook will inject envoy containers in any pod a
 | marin3r.3scale.net/tls-volume         | the pod volume where the marin3r client certificate will be mounted.                                                        | envoy-sidecar-tls         |
 | marin3r.3scale.net/client-certificate | the marin3r client certificate to use to authenticate to the marin3r control plane (marin3r uses mTLS))                     | envoy-sidecar-client-cert |
 | marin3r.3scale.net/envoy-extra-args   | extra command line arguments to pass to the envoy sidecar container                                                         | ""                        |
+| marin3r.3scale.net/resources.limits.cpu   | envoy sidecar container resource cpu limits. See [syntax format](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#quantity-resource-core) to specify the resource quantity | N/A |
+| marin3r.3scale.net/resources.limits.memory | envoy sidecar container resource memory limits. See [syntax format](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#quantity-resource-core) to specify the resource quantity | N/A |
+| marin3r.3scale.net/resources.requests.cpu | envoy sidecar container resource cpu requests. See [syntax format](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#quantity-resource-core) to specify the resource quantity | N/A |
+| marin3r.3scale.net/resources.requests.memory | envoy sidecar container resource memory requests. See [syntax format](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#quantity-resource-core) to specify the resource quantity | N/A |
 
 <!-- omit in toc -->
 #### `marin3r.3scale.net/ports` syntax

--- a/pkg/webhooks/podv1mutator/sidecar.go
+++ b/pkg/webhooks/podv1mutator/sidecar.go
@@ -103,7 +103,7 @@ func getStringParam(key string, annotations map[string]string) string {
 	}
 
 	// return the value specified in the corresponding annotation, if any
-	if value, ok := annotations[fmt.Sprintf("%s/%s", marin3rAnnotationsDomain, key)]; ok {
+	if value, ok := lookupMarin3rAnnotation(key, annotations); ok {
 		return value
 	}
 
@@ -121,7 +121,8 @@ func getStringParam(key string, annotations map[string]string) string {
 func getNodeID(annotations map[string]string) string {
 	// the node-id annotation is always present, otherwise
 	// mutation won't even be triggered
-	return annotations[fmt.Sprintf("%s/%s", marin3rAnnotationsDomain, paramNodeID)]
+	res, _ := lookupMarin3rAnnotation(paramNodeID, annotations)
+	return res
 }
 
 func (esc *envoySidecarConfig) PopulateFromAnnotations(annotations map[string]string) error {
@@ -204,8 +205,7 @@ func getContainerResourceRequirements(annotations map[string]string) (corev1.Res
 func getContainerPorts(annotations map[string]string) ([]corev1.ContainerPort, error) {
 	plist := []corev1.ContainerPort{}
 
-	if ports, ok := annotations[fmt.Sprintf("%s/%s", marin3rAnnotationsDomain, paramPorts)]; ok {
-
+	if ports, ok := lookupMarin3rAnnotation(paramPorts, annotations); ok {
 		for _, containerPort := range strings.Split(ports, ",") {
 
 			p, err := parsePortSpec(containerPort)
@@ -264,7 +264,7 @@ func parsePortSpec(spec string) (*corev1.ContainerPort, error) {
 
 func hostPortMapping(portName string, annotations map[string]string) (int32, error) {
 
-	if specs, ok := annotations[fmt.Sprintf("%s/%s", marin3rAnnotationsDomain, paramHostPortMapings)]; ok {
+	if specs, ok := lookupMarin3rAnnotation(paramHostPortMapings, annotations); ok {
 		for _, spec := range strings.Split(specs, ",") {
 			params := strings.Split(spec, ":")
 			if len(params) != 2 {


### PR DESCRIPTION
This PR adds configurable resource requirements for Envoy sidecar in Webhook.

Design:

The following annotations have been created that can be added into a ServiceDiscovery object.

```
        marin3r.3scale.net/resources.limits.cpu
        marin3r.3scale.net/resources.limits.memory
        marin3r.3scale.net/resources.requests.cpu
        marin3r.3scale.net/resources.requests.memory
```

The values have to follow the format of a Kubernetes `Quantity` https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#quantity-resource-core.

Because a `Quantity` cannot be specified as the empty string if a user specifies one of those annotation keys and it sets its value as the empty string `""` an error is returned at code level. This is one of the reasons the code implementation of the quantities parsing is surprisingly more complex than expected.

When an invalid `Quantity` is specified an error is returned. This is shown as an error in the `Deployment` object where the envoy sidecar is to be injected.

For example, if the user sets an invalid quantity value in the Deployment (kuard in our typical example) the following  condition is shown:
```
  - lastTransitionTime: "2020-10-30T19:30:16Z"
    lastUpdateTime: "2020-10-30T19:30:16Z"
    message: 'admission webhook "sidecar-injector.marin3r.3scale.net" denied the request:
      Error trying to load envoy container config from annotations: ''unable to parse
      quantity''s suffix'''
    reason: FailedCreate
    status: "True"
    type: ReplicaFailure
```

or also this one:

```
  - lastTransitionTime: "2020-10-30T19:44:36Z"
    lastUpdateTime: "2020-10-30T19:44:36Z"
    message: 'admission webhook "sidecar-injector.marin3r.3scale.net" denied the request:
      Error trying to load envoy container config from annotations: ''quantities must
      match the regular expression ''^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'''''
    reason: FailedCreate
```

Let me know your thoughts on this.

Pending:

- [x] Documentation
- [x] Testing