### PR TITLE
Increase memory request/limit of controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,10 +34,10 @@ spec:
         resources:
           limits:
             cpu: 300m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
       terminationGracePeriodSeconds: 10
 
 ---


### PR DESCRIPTION
We have seen that under some conditions, controller-manager needs on startup more than 100 MB (which was the limit), so OMMKiller was acting, leaving the pod on `CrashLoopBackoff` status (average memory usage seems 100Mb).

So, I have increased  memory requests to 100MB (was the average usage), and a limit of 300Mb (which should be enough for most of the scenarios).