### PR TITLE
fix/secret-controller

### DIFF
--- a/pkg/discoveryservice/manager.go
+++ b/pkg/discoveryservice/manager.go
@@ -126,6 +126,15 @@ func (dsm *Manager) Start(ctx context.Context) {
 		os.Exit(1)
 	}
 
+	if err := (&envoycontroller.SecretReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("secret"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "secret")
+		os.Exit(1)
+	}
+
 	// Setup webhooks
 	hookServer := mgr.GetWebhookServer()
 	hookServer.CertDir = dsm.ServerCertificatePath

--- a/test/e2e/04-certificates/00-assert.yaml
+++ b/test/e2e/04-certificates/00-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marin3r-instance
+status:
+  readyReplicas: 1
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-sidecar-bootstrap
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: envoy-sidecar-client-cert

--- a/test/e2e/04-certificates/00-install.yaml
+++ b/test/e2e/04-certificates/00-install.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: echo "{\"apiVersion\":\"operator.marin3r.3scale.net/v1alpha1\",\"kind\":\"DiscoveryService\",\"metadata\":{\"name\":\"instance\"},\"spec\":{\"image\":\"quay.io/3scale/marin3r:test\",\"debug\":true,\"discoveryServiceNamespace\":\"$NAMESPACE\",\"enabledNamespaces\":[\"$NAMESPACE\"]}}" | kubectl apply -f -

--- a/test/e2e/04-certificates/01-pod.yaml
+++ b/test/e2e/04-certificates/01-pod.yaml
@@ -1,0 +1,93 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Create a certificate to be delivered to envoy through xDS
+  - command: openssl req -x509 -newkey rsa:2048 -keyout /tmp/key.pem -out /tmp/cert.pem -days 1 -nodes -subj '/CN=envoy1.defaul.svc'
+  - command: kubectl create secret tls envoy1-cert --cert=/tmp/cert.pem --key=/tmp/key.pem
+    namespaced: true
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: envoy1
+spec:
+  containers:
+    - name: envoy
+      image: envoyproxy/envoy:v1.14.1
+      command: ["envoy"]
+      args:
+        [
+          "-c",
+          "/etc/envoy/bootstrap/config.json",
+          "--component-log-level",
+          "http:debug,connection:debug",
+          "--service-cluster",
+          "envoy1",
+          "--service-node",
+          "envoy1",
+        ]
+      ports:
+        - name: admin
+          containerPort: 9901
+          protocol: TCP
+        - name: https
+          containerPort: 8443
+          hostPort: 8443
+          protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /ready
+          port: admin
+        failureThreshold: 1
+        periodSeconds: 5
+      volumeMounts:
+        - name: envoy-sidecar-bootstrap
+          mountPath: /etc/envoy/bootstrap
+        - name: envoy-sidecar-client-cert
+          mountPath: /etc/envoy/tls/client
+  volumes:
+    - name: envoy-sidecar-bootstrap
+      configMap:
+        name: envoy-sidecar-bootstrap
+    - name: envoy-sidecar-client-cert
+      secret:
+        secretName: envoy-sidecar-client-cert
+
+---
+apiVersion: envoy.marin3r.3scale.net/v1alpha1
+kind: EnvoyConfig
+metadata:
+  name: proxy-config
+spec:
+  nodeID: envoy1
+  serialization: yaml
+  envoyResources:
+    listeners:
+      - name: https
+        value: |
+          name: https
+          address: { socket_address: { address: 0.0.0.0, port_value: 8443 }}
+          filter_chains:
+            - filters:
+              - name: envoy.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                  stat_prefix: ingress_http
+                  route_config:
+                    name: local_route
+                    virtual_hosts:
+                      - name: my-proxy
+                        domains: ["*"]
+                        routes:
+                          - match: { prefix: "/" }
+                            direct_response: { status: 200, body: { inline_string: ok }}
+                  http_filters: [ name: envoy.router ]
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  "@type": "type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext"
+                  common_tls_context:
+                    tls_certificate_sds_secret_configs:
+                      - name: envoy1.defaul.svc
+                        sds_config: { ads: {}}

--- a/test/e2e/04-certificates/02-assert.yaml
+++ b/test/e2e/04-certificates/02-assert.yaml
@@ -1,0 +1,33 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: envoy1
+status:
+  phase: Running
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: envoy1-cert
+
+---
+apiVersion: envoy.marin3r.3scale.net/v1alpha1
+kind: EnvoyConfig
+metadata:
+  name: proxy-config
+spec:
+  nodeID: envoy1
+status:
+  cacheState: InSync
+
+---
+apiVersion: envoy.marin3r.3scale.net/v1alpha1
+kind: EnvoyConfigRevision
+spec:
+  nodeID: envoy1

--- a/test/e2e/04-certificates/02-patch-envoyconfig.yaml
+++ b/test/e2e/04-certificates/02-patch-envoyconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Add the reference to the secret in the envoy config
+  - script: kubectl -n $NAMESPACE patch envoyconfig --type merge proxy-config --patch "{\"spec\":{\"envoyResources\":{\"secrets\":[{\"name\":\"envoy1.defaul.svc\",\"ref\":{\"name\":\"envoy1-cert\", \"namespace\":\"$NAMESPACE\"}}]}}}"
+

--- a/test/e2e/04-certificates/03-validate-cert.yaml
+++ b/test/e2e/04-certificates/03-validate-cert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sleep 1
+  # Validate that the certificate has been delivered through xDS to the envoy container
+  - script: subject=$(echo "Q" | openssl s_client -connect localhost:1443 -showcerts | openssl x509 -in - -noout -subject) && echo "$subject/n" && test "$subject" = "subject=CN = envoy1.defaul.svc"

--- a/test/e2e/04-certificates/04-reissue-certificate.yaml
+++ b/test/e2e/04-certificates/04-reissue-certificate.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete secret envoy1-cert
+    namespaced: true
+  - command: openssl req -x509 -newkey rsa:2048 -keyout /tmp/key.pem -out /tmp/cert.pem -days 1 -nodes -subj '/CN=envoy1-new.defaul.svc'
+  - command: kubectl create secret tls envoy1-cert --cert=/tmp/cert.pem --key=/tmp/key.pem
+    namespaced: true

--- a/test/e2e/04-certificates/05-validate-new-cert.yaml
+++ b/test/e2e/04-certificates/05-validate-new-cert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sleep 1
+  # Validate that the certificate has been delivered through xDS to the envoy container
+  - script: subject=$(echo "Q" | openssl s_client -connect localhost:1443 -showcerts | openssl x509 -in - -noout -subject) && echo "$subject/n" && test "$subject" = "subject=CN = envoy1-new.defaul.svc"

--- a/test/e2e/04-certificates/06-cleanup.yaml
+++ b/test/e2e/04-certificates/06-cleanup.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete envoyconfig proxy-config
+    namespaced: true
+  - command: kubectl delete discoveryservice instance


### PR DESCRIPTION
In the upgrade to operator-sdk 1.1 (#34) a regression was introduced and the mechanism to publish new versions of certificates in the discovery service by watching for changes in Secret resources was deactivated by mistake. The controller in charge of this task was no instantiated in the discovery service, thus certificates were only loaded/reloaded when reconciles to EnvoyConfigRevision resources occurred, and never triggered by changes in the Secret resource itself. This problem slipped by as there was no e2e test covering this.

This PR adds the secrets controller back to the discovery service manager and also adds an e2e test to cover the feature.