### PR TITLE
Fix: do not taint revisions with Secret related errors

### DIFF
--- a/controllers/marin3r/envoyconfigrevision_controller_test.go
+++ b/controllers/marin3r/envoyconfigrevision_controller_test.go
@@ -33,7 +33,7 @@ func TestEnvoyConfigRevisionReconciler_taintSelf(t *testing.T) {
 			XdsCache: xdss_v2.NewCache(cache_v2.NewSnapshotCache(true, cache_v2.IDHash{}, nil)),
 			Log:      ctrl.Log.WithName("test"),
 		}
-		if err := r.taintSelf(context.TODO(), ecr, "test", "test"); err != nil {
+		if err := r.taintSelf(context.TODO(), ecr, "test", "test", r.Log); err != nil {
 			t.Errorf("EnvoyConfigRevisionReconciler.taintSelf() error = %v", err)
 		}
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "ecr", Namespace: "default"}, ecr)

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
@@ -138,7 +138,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 			Namespace: secret.Ref.Namespace,
 		}
 		if err := r.client.Get(r.ctx, key, s); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s", err.Error())
 		}
 
 		// Validate secret holds a certificate
@@ -146,11 +146,11 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 			res := r.generator.NewSecret(secret.Name, string(s.Data[secretPrivateKey]), string(s.Data[secretCertificate]))
 			snap.SetResource(secret.Name, res)
 		} else {
-			return nil,
-				resourceLoaderError(
-					req, secret.Ref, field.NewPath("spec", "resources").Child("secrets").Index(idx).Child("ref"),
-					"Only 'kubernetes.io/tls' type secrets allowed",
-				)
+			err := resourceLoaderError(
+				req, secret.Ref, field.NewPath("spec", "resources").Child("secrets").Index(idx).Child("ref"),
+				"Only 'kubernetes.io/tls' type secrets allowed",
+			)
+			return nil, fmt.Errorf("%s", err.Error())
 
 		}
 	}


### PR DESCRIPTION
This should have been already fixed but looks like both spec resources and secrets were returning the same error type. This commit fixes that and also adds test to avoid future regressions.